### PR TITLE
autoprefixer-core dependency changed to version 5 major

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "less-plugin-autoprefix",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "description": "autoprefixer plugin for less.js",
     "homepage": "http://lesscss.org",
     "author": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "node": ">=0.4.2"
     },
 	"dependencies": {
-        "autoprefixer-core": "~5.0.0"
+        "autoprefixer-core": "^5.0.0"
 	},
     "devDependencies": {
     },


### PR DESCRIPTION
The version 1.3.0 targeted __autoprefixer-core__ package __~5.0.0__; the proposed pull request targets __autoprefixer-core__ version __^5.0.0__. 

This is a switch from targeting _minor_ versions 5.0.x to _major_ versions 5.x.x, so that more frequent updates of the __autoprefixer-core__ are possible as long as it remains on version 5 (Current versions 5.1.x, and beyond, up to but not including 6).
