### PR TITLE
Fixed sending extra spaces into browserlist

### DIFF
--- a/lib/parse-options.js
+++ b/lib/parse-options.js
@@ -1,6 +1,6 @@
 module.exports = function(options) {
     if (typeof options === 'string') {
-        var browsers = options.split(",");
+        var browsers = options.replace(/\s*,\s*/g, ",").split(",");
         options = {browsers: browsers};
     }
     return options;


### PR DESCRIPTION
Given a browserslist string of `last 2 versions,> 1%` `autoprefixer-core` will fail because the list of browsers are given as a list and not a string. 

If giving the browsers as a list, it needs to be *perfect*, which means that extra spaces must be trimmed.

Using just browserslist directly doesn't reproduce the problem: 

```javascript
> require('browserslist')('last 2 versions,> 1%').length
24
```

But sending the same list into `lessc` with the `--autoprefix` option will cause silent failure:

```bash
$ echo 'a {transition: all 1s;}' | lessc --autoprefix='last 2 versions,> 1%' -
a {
  -webkit-transition: all 1s;
          transition: all 1s;
}
$ echo 'a {transition: all 1s;}' | lessc --autoprefix='last 2 versions, > 1%' -
undefined
```

This PR handles the issue with a simple regexp replace.