### PR TITLE
Update syntax for autoprefixer 5.2.1

### DIFF
--- a/lib/autoprefix-processor.js
+++ b/lib/autoprefix-processor.js
@@ -1,4 +1,5 @@
 var autoprefixer = require('autoprefixer-core');
+var postcss = require('postcss');
 
 module.exports = function(less) {
     function AutoprefixProcessor(options) {
@@ -28,7 +29,7 @@ module.exports = function(less) {
                 }
             }
 
-            var processed = autoprefixer(options).process(css, processOptions);
+            var processed = postcss([autoprefixer(options)]).process(css, processOptions);
 
             if (sourceMap && !sourceMapInline) {
                 sourceMap.setExternalSourceMap(processed.map);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
         "node": ">=0.4.2"
     },
 	"dependencies": {
-        "autoprefixer-core": "^5.0.0"
+        "autoprefixer-core": "^5.0.0",
+        "postcss": "^4.1.11"
 	},
     "devDependencies": {
     },


### PR DESCRIPTION
Fixes issue #13.

This commit incorporates changes to autoprefixer's API. This will remove a warning, as mentioned in #13.