### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install -g less-plugin-autoprefix
 and then on the command line,
 
 ```
-lessc file.less --autoprefix="browsers"
+lessc file.less --autoprefix
 ```
 
 The browsers are a comma seperated list of [browsers as specified with autoprefixer](https://github.com/postcss/autoprefixer#browsers).


### PR DESCRIPTION
Adding " ="browsers" " to --autoprefix seems to do nothing (It only returns `undefined`).

It works well with `--autoprefix`. Don't really know if it's a bug or a feature :blush:.
