### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "less-plugin-autoprefix",
-    "version": "1.5.1",
+    "version": "1.6.0",
     "description": "autoprefixer plugin for less.js",
     "homepage": "http://lesscss.org",
     "author": {
@@ -16,25 +16,20 @@
         "type": "git",
         "url": "https://github.com/less/less-plugin-autoprefix.git"
     },
-    "licenses": [
-        {
-            "type": "Apache v2",
-            "url": "https://github.com/less/less-plugin-autoprefix/blob/master/LICENSE"
-        }
-    ],
+    "license": "Apache-2.0",
     "main": "lib/index.js",
     "engines": {
-        "node": ">=0.4.2"
+        "node": ">=4.0.0"
     },
     "dependencies": {
-        "autoprefixer": "^6.0.0",
-        "postcss": "^5.0.0"
+        "autoprefixer": "^7.1.0",
+        "postcss": "^6.0.0"
     },
     "devDependencies": {
     },
     "keywords": [
         "less plugins",
-	    "autoprefixer",
-	    "less prefixes"
+        "autoprefixer",
+        "less prefixes"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "license": "Apache-2.0",
     "main": "lib/index.js",
     "engines": {
-        "node": ">=4.0.0"
+        "node": ">=4"
     },
     "dependencies": {
-        "autoprefixer": "^7.1.0",
+        "autoprefixer": "^7",
         "postcss": "^6.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
- Changed licenses field to use an SPDX expression [as recommended](https://docs.npmjs.com/files/package.json#license) (old format is deprecated)
- Dependencies upgraded to latest Autoprefixer and PostCSS. Node dependency also bumped up as PostCSS 6 requires Node 4+.