### PR TITLE
update autoprefixer to 8.6.3 & postcss to 6.0.22 (fix #33)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "less-plugin-autoprefix",
-    "version": "1.5.1",
+    "version": "2.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,167 @@
+{
+    "name": "less-plugin-autoprefix",
+    "version": "1.5.1",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
+        },
+        "autoprefixer": {
+            "version": "8.6.3",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.6.3.tgz",
+            "integrity": "sha512-KkQyCHBxma7R2eoEkjja/RHUBw+Fc1nY46LdV62fzJI5D7i8mLLCtAZ/AVR3UbXhDZ8mUz4C/PF4lZrbiHa1ZQ==",
+            "requires": {
+                "browserslist": "^3.2.8",
+                "caniuse-lite": "^1.0.30000856",
+                "normalize-range": "^0.1.2",
+                "num2fraction": "^1.2.2",
+                "postcss": "^6.0.22",
+                "postcss-value-parser": "^3.2.3"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+                },
+                "postcss": {
+                    "version": "6.0.22",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
+                    "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+                    "requires": {
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "browserslist": {
+            "version": "3.2.8",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+            "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+            "requires": {
+                "caniuse-lite": "^1.0.30000844",
+                "electron-to-chromium": "^1.3.47"
+            }
+        },
+        "caniuse-lite": {
+            "version": "1.0.30000856",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000856.tgz",
+            "integrity": "sha512-x3mYcApHMQemyaHuH/RyqtKCGIYTgEA63fdi+VBvDz8xUSmRiVWTLeyKcoGQCGG6UPR9/+4qG4OKrTa6aSQRKg=="
+        },
+        "chalk": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+            "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            }
+        },
+        "color-convert": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+            "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+            "requires": {
+                "color-name": "1.1.1"
+            }
+        },
+        "color-name": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+            "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
+        },
+        "electron-to-chromium": {
+            "version": "1.3.48",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz",
+            "integrity": "sha1-07DYWTgUBE4JLs4hCPw6ya6kuQA="
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "normalize-range": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+            "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+        },
+        "num2fraction": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+            "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
+        },
+        "postcss": {
+            "version": "6.0.22",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
+            "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+            "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+            }
+        },
+        "postcss-value-parser": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+            "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
+        },
+        "source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "supports-color": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+            "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+            "requires": {
+                "has-flag": "^3.0.0"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     ],
     "main": "lib/index.js",
     "engines": {
-        "node": ">=0.4.2"
+        "node": ">=4.0.0"
     },
     "dependencies": {
         "autoprefixer": "^8.6.3",

--- a/package.json
+++ b/package.json
@@ -27,14 +27,13 @@
         "node": ">=0.4.2"
     },
     "dependencies": {
-        "autoprefixer": "^6.0.0",
-        "postcss": "^5.0.0"
+        "autoprefixer": "^8.6.3",
+        "postcss": "^6.0.22"
     },
-    "devDependencies": {
-    },
+    "devDependencies": {},
     "keywords": [
         "less plugins",
-	    "autoprefixer",
-	    "less prefixes"
+        "autoprefixer",
+        "less prefixes"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "less-plugin-autoprefix",
-    "version": "1.5.1",
+    "version": "2.0.0",
     "description": "autoprefixer plugin for less.js",
     "homepage": "http://lesscss.org",
     "author": {


### PR DESCRIPTION
I'm not sure what version to bump (major, minor, patch), and I could use help figuring out what the new minimum Node version requirement is (I tested with 8.11.3).