### PR TITLE
Updated autoprefixer to the last version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "less-plugin-autoprefix",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -13,79 +13,32 @@
             }
         },
         "autoprefixer": {
-            "version": "8.6.3",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.6.3.tgz",
-            "integrity": "sha512-KkQyCHBxma7R2eoEkjja/RHUBw+Fc1nY46LdV62fzJI5D7i8mLLCtAZ/AVR3UbXhDZ8mUz4C/PF4lZrbiHa1ZQ==",
+            "version": "9.4.3",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.3.tgz",
+            "integrity": "sha512-/XSnzDepRkAU//xLcXA/lUWxpsBuw0WiriAHOqnxkuCtzLhaz+fL4it4gp20BQ8n5SyLzK/FOc7A0+u/rti2FQ==",
             "requires": {
-                "browserslist": "^3.2.8",
-                "caniuse-lite": "^1.0.30000856",
+                "browserslist": "^4.3.6",
+                "caniuse-lite": "^1.0.30000921",
                 "normalize-range": "^0.1.2",
                 "num2fraction": "^1.2.2",
-                "postcss": "^6.0.22",
-                "postcss-value-parser": "^3.2.3"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
-                "has-flag": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-                },
-                "postcss": {
-                    "version": "6.0.22",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-                    "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
-                    "requires": {
-                        "chalk": "^2.4.1",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^5.4.0"
-                    }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-                },
-                "supports-color": {
-                    "version": "5.4.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
+                "postcss": "^7.0.6",
+                "postcss-value-parser": "^3.3.1"
             }
         },
         "browserslist": {
-            "version": "3.2.8",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
-            "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.6.tgz",
+            "integrity": "sha512-kMGKs4BTzRWviZ8yru18xBpx+CyHG9eqgRbj9XbE3IMgtczf4aiA0Y1YCpVdvUieKGZ03kolSPXqTcscBCb9qw==",
             "requires": {
-                "caniuse-lite": "^1.0.30000844",
-                "electron-to-chromium": "^1.3.47"
+                "caniuse-lite": "^1.0.30000921",
+                "electron-to-chromium": "^1.3.92",
+                "node-releases": "^1.1.1"
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30000856",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000856.tgz",
-            "integrity": "sha512-x3mYcApHMQemyaHuH/RyqtKCGIYTgEA63fdi+VBvDz8xUSmRiVWTLeyKcoGQCGG6UPR9/+4qG4OKrTa6aSQRKg=="
+            "version": "1.0.30000921",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000921.tgz",
+            "integrity": "sha512-Bu09ciy0lMWLgpYC77I0YGuI8eFRBPPzaSOYJK1jTI64txCphYCqnWbxJYjHABYVt/TYX/p3jNjLBR87u1Bfpw=="
         },
         "chalk": {
             "version": "2.4.1",
@@ -98,22 +51,22 @@
             }
         },
         "color-convert": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
-            "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
             "requires": {
-                "color-name": "1.1.1"
+                "color-name": "1.1.3"
             }
         },
         "color-name": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-            "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "electron-to-chromium": {
-            "version": "1.3.48",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz",
-            "integrity": "sha1-07DYWTgUBE4JLs4hCPw6ya6kuQA="
+            "version": "1.3.95",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.95.tgz",
+            "integrity": "sha512-0JZEDKOQAE05EO/4rk3vLAE+PYFI9OLCVLAS4QAq1y+Bb2y1N6MyQJz62ynzHN/y0Ka/nO5jVJcahbCEdfiXLQ=="
         },
         "escape-string-regexp": {
             "version": "1.0.5",
@@ -124,6 +77,14 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "node-releases": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.2.tgz",
+            "integrity": "sha512-j1gEV/zX821yxdWp/1vBMN0pSUjuH9oGUdLCb4PfUko6ZW7KdRs3Z+QGGwDUhYtSpQvdVVyLd2V0YvLsmdg5jQ==",
+            "requires": {
+                "semver": "^5.3.0"
+            }
         },
         "normalize-range": {
             "version": "0.1.2",
@@ -136,19 +97,24 @@
             "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
         },
         "postcss": {
-            "version": "6.0.22",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-            "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+            "version": "7.0.7",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+            "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
             "requires": {
                 "chalk": "^2.4.1",
                 "source-map": "^0.6.1",
-                "supports-color": "^5.4.0"
+                "supports-color": "^5.5.0"
             }
         },
         "postcss-value-parser": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
-            "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+            "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+        },
+        "semver": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
         },
         "source-map": {
             "version": "0.6.1",
@@ -156,9 +122,9 @@
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-            "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "requires": {
                 "has-flag": "^3.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "less-plugin-autoprefix",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "autoprefixer plugin for less.js",
     "homepage": "http://lesscss.org",
     "author": {
@@ -24,11 +24,11 @@
     ],
     "main": "lib/index.js",
     "engines": {
-        "node": ">=4.0.0"
+        "node": ">=6.0.0"
     },
     "dependencies": {
-        "autoprefixer": "^8.6.3",
-        "postcss": "^6.0.22"
+        "autoprefixer": "^9.4.3",
+        "postcss": "^7.0.6"
     },
     "devDependencies": {},
     "keywords": [


### PR DESCRIPTION
Issue #38 

### Updated versions of:

- [ ] autoprefixer to 9.4.3 
- [ ] postcss to 7.0.6
- [ ] node to 6.0.0

### Bump files version:
- [ ] package and package-lock to 2.1.0

