### PR TITLE
Fix a breakage when using the plugin with --source-map on Node 14+.

### DIFF
--- a/lib/autoprefix-processor.js
+++ b/lib/autoprefix-processor.js
@@ -38,7 +38,7 @@ module.exports = function(less) {
             var processed = postcss([autoprefixer(options)]).process(css, processOptions);
 
             if (sourceMap && !sourceMapInline) {
-                sourceMap.setExternalSourceMap(processed.map);
+                sourceMap.setExternalSourceMap(processed.map.toString());
             }
 
             return processed.css;


### PR DESCRIPTION
A Node.js 14.x added strict type checking when writing files to disk, preventing methods with their own `.toString()` method from being written to disk and generating a `ERR_INVALID_ARG_TYPE` error in the process. This affected using this plugin in combination with `--source-map`.

The behavioral change was introduced in https://github.com/nodejs/node/pull/31030 and recently fixed in https://github.com/nodejs/node/pull/34993. That fix was not comprehensive, and did not resolve the issue for the plugin.

To avoid this issue for all versions of Node, we no longer assume there will be an implicit call to `SourceMapGenerator.toString()`. Instead, it's now explicitly called when setting the data to write for the source map, fixing source map generation.

This was tested on the latest releases of Node 12 through 15.